### PR TITLE
Dispose message handlers on webview dispose

### DIFF
--- a/packages/sprotty-vscode-protocol/package.json
+++ b/packages/sprotty-vscode-protocol/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "sprotty-protocol": "~0.13.0",
     "vscode-languageserver-protocol": "^3.17.2",
-    "vscode-messenger-common": "^0.4.3"
+    "vscode-messenger-common": "^0.4.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.30.0",

--- a/packages/sprotty-vscode-webview/package.json
+++ b/packages/sprotty-vscode-webview/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "sprotty": "~0.13.0",
     "sprotty-vscode-protocol": "^0.5.0",
-    "vscode-messenger-webview": "^0.4.3",
+    "vscode-messenger-webview": "^0.4.5",
     "vscode-uri": "^3.0.6"
   },
   "devDependencies": {

--- a/packages/sprotty-vscode/package.json
+++ b/packages/sprotty-vscode/package.json
@@ -46,7 +46,7 @@
     "path": "^0.12.7",
     "sprotty-vscode-protocol": "^0.5.0",
     "vscode-languageclient": "^8.0.2",
-    "vscode-messenger": "^0.4.4"
+    "vscode-messenger": "^0.4.5"
   },
   "devDependencies": {
     "@types/node": "^12.12.6",

--- a/packages/sprotty-vscode/src/lsp/lsp-webview-endpoint.ts
+++ b/packages/sprotty-vscode/src/lsp/lsp-webview-endpoint.ts
@@ -40,25 +40,29 @@ export class LspWebviewEndpoint extends WebviewEndpoint {
 
     protected override connect(): void {
         super.connect();
-        this.messenger.onRequest(LspRequest,
-            async request => {
-                const result: any = request.params === undefined
-                    ? await this.languageClient.sendRequest(request.method)
-                    : await this.languageClient.sendRequest(request.method, request.params);
-                const response: ResponseMessage = {
-                    jsonrpc: '2.0',
-                    id: request.id,
-                    result
-                };
-                return response;
-            },
-            { sender: this.messageParticipant }
+        this.disposables.push(
+            this.messenger.onRequest(LspRequest,
+                async request => {
+                    const result: any = request.params === undefined
+                        ? await this.languageClient.sendRequest(request.method)
+                        : await this.languageClient.sendRequest(request.method, request.params);
+                    const response: ResponseMessage = {
+                        jsonrpc: '2.0',
+                        id: request.id,
+                        result
+                    };
+                    return response;
+                },
+                { sender: this.messageParticipant }
+            )
         );
-        this.messenger.onNotification(LspNotification,
-            notification => {
-                this.languageClient.sendNotification(notification.method, notification.params);
-            },
-            { sender: this.messageParticipant }
+        this.disposables.push(
+            this.messenger.onNotification(LspNotification,
+                notification => {
+                    this.languageClient.sendNotification(notification.method, notification.params);
+                },
+                { sender: this.messageParticipant }
+            )
         );
     }
 

--- a/packages/sprotty-vscode/src/webview-endpoint.ts
+++ b/packages/sprotty-vscode/src/webview-endpoint.ts
@@ -104,16 +104,20 @@ export class WebviewEndpoint {
                 })
             );
         }
-        this.messenger.onNotification(ActionNotification,
-            message => this.receiveAction(message),
-            { sender: this.messageParticipant }
+        this.disposables.push(
+            this.messenger.onNotification(ActionNotification,
+                message => this.receiveAction(message),
+                { sender: this.messageParticipant }
+            )
         );
-        this.messenger.onNotification(WebviewReadyNotification,
-            message => {
-                this.resolveWebviewReady();
-                this.sendDiagramIdentifier();
-            },
-            { sender: this.messageParticipant }
+        this.disposables.push(
+            this.messenger.onNotification(WebviewReadyNotification,
+                message => {
+                    this.resolveWebviewReady();
+                    this.sendDiagramIdentifier();
+                },
+                { sender: this.messageParticipant }
+            )
         );
     }
 


### PR DESCRIPTION
Removes request/notification handlers from Messenger when a view is closed. 
Also updated  [vscode-messenger](https://github.com/TypeFox/vscode-messenger) dependency to the most recent one.

See #85  