### PR TITLE
Automatically open Webviewview if closed

### DIFF
--- a/examples/states-langium/extension/src/states-extension.ts
+++ b/examples/states-langium/extension/src/states-extension.ts
@@ -19,6 +19,7 @@ import { registerDefaultCommands, registerTextEditorSync } from 'sprotty-vscode'
 import { LspSprottyEditorProvider, LspSprottyViewProvider, LspWebviewPanelManager } from 'sprotty-vscode/lib/lsp';
 import * as vscode from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
+import { Messenger } from 'vscode-messenger';
 
 let languageClient: LanguageClient;
 
@@ -64,7 +65,8 @@ export function activate(context: vscode.ExtensionContext) {
             viewType: 'states',
             languageClient,
             supportedFileExtensions: ['.sm'],
-            openActiveEditor: true
+            openActiveEditor: true,
+            messenger: new Messenger({ignoreHiddenViews: false})
         });
         context.subscriptions.push(
             vscode.window.registerWebviewViewProvider('states', webviewViewProvider, {

--- a/packages/sprotty-vscode/src/sprotty-view-provider.ts
+++ b/packages/sprotty-vscode/src/sprotty-view-provider.ts
@@ -72,8 +72,8 @@ export class SprottyViewProvider implements vscode.WebviewViewProvider, IWebview
             if (options.reveal && isWebviewView(endpoint.webviewContainer)) {
                 endpoint.webviewContainer.show(options.preserveFocus);
             }
-        } else if (!options.quiet) {
-            vscode.window.showErrorMessage(`The ${this.options.viewType} view cannot be opened programmatically. Select 'View' > 'Open View' in the main menu to open it.`);
+        } else {
+            vscode.commands.executeCommand(`${identifier.diagramType}.focus`);
         }
         return endpoint;
     }


### PR DESCRIPTION
If the webviewview hosting Sprotty is not open, we can force it to show with a focus command. This will also send the focus to the newly opened view.

There might be a better solution coming in the near future from VSCode (see https://github.com/microsoft/vscode/issues/146330)