### PR TITLE
Add meta content security policy to generated html

### DIFF
--- a/examples/states-webview/webpack.config.js
+++ b/examples/states-webview/webpack.config.js
@@ -12,7 +12,7 @@ const config = {
 		filename: 'webview.js',
         path: outputPath
     },
-    devtool: 'eval-source-map',
+    devtool: 'source-map',
 
     resolve: {
         extensions: ['.ts', '.tsx', '.js']

--- a/packages/sprotty-vscode/src/sprotty-editor-provider.ts
+++ b/packages/sprotty-vscode/src/sprotty-editor-provider.ts
@@ -17,7 +17,7 @@
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import * as vscode from 'vscode';
 import { Messenger } from 'vscode-messenger';
-import { isWebviewPanel, IWebviewEndpointManager, OpenDiagramOptions, WebviewEndpoint } from './webview-endpoint';
+import { isWebviewPanel, IWebviewEndpointManager, OpenDiagramOptions, WebviewContainer, WebviewEndpoint } from './webview-endpoint';
 import { createFileUri, createWebviewHtml, getExtname, serializeUri } from './webview-utils';
 
 export interface SprottyEditorProviderOptions {
@@ -25,6 +25,8 @@ export interface SprottyEditorProviderOptions {
     viewType: string
     messenger?: Messenger
     supportedFileExtensions?: string[];
+    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer,
+        options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }) => string
 }
 
 export type CustomDocumentChangeEvent = vscode.CustomDocumentEditEvent<vscode.CustomDocument> | vscode.CustomDocumentContentChangeEvent<vscode.CustomDocument>;
@@ -122,7 +124,11 @@ export class SprottyEditorProvider implements vscode.CustomEditorProvider, IWebv
         const identifier = document.endpoint?.diagramIdentifier;
         if (identifier) {
             const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
-            webviewPanel.webview.html = createWebviewHtml(identifier, webviewPanel, { scriptUri });
+            if (this.options.createWebviewHtml) {
+                this.options.createWebviewHtml(identifier, webviewPanel, { scriptUri });
+            } else {
+                webviewPanel.webview.html = createWebviewHtml(identifier, webviewPanel, { scriptUri });
+            }
         }
     }
 

--- a/packages/sprotty-vscode/src/sprotty-editor-provider.ts
+++ b/packages/sprotty-vscode/src/sprotty-editor-provider.ts
@@ -124,7 +124,7 @@ export class SprottyEditorProvider implements vscode.CustomEditorProvider, IWebv
         const identifier = document.endpoint?.diagramIdentifier;
         if (identifier) {
             if (this.options.createWebviewHtml) {
-                this.options.createWebviewHtml(identifier, webviewPanel);
+                webviewPanel.webview.html = this.options.createWebviewHtml(identifier, webviewPanel);
             } else {
                 const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
                 webviewPanel.webview.html = createWebviewHtml(identifier, webviewPanel, { scriptUri });

--- a/packages/sprotty-vscode/src/sprotty-editor-provider.ts
+++ b/packages/sprotty-vscode/src/sprotty-editor-provider.ts
@@ -24,9 +24,9 @@ export interface SprottyEditorProviderOptions {
     extensionUri: vscode.Uri
     viewType: string
     messenger?: Messenger
-    supportedFileExtensions?: string[];
-    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer,
-        options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }) => string
+    supportedFileExtensions?: string[]
+    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer) => string
+    localResourceRoots?: vscode.Uri[]
 }
 
 export type CustomDocumentChangeEvent = vscode.CustomDocumentEditEvent<vscode.CustomDocument> | vscode.CustomDocumentContentChangeEvent<vscode.CustomDocument>;
@@ -118,15 +118,15 @@ export class SprottyEditorProvider implements vscode.CustomEditorProvider, IWebv
     protected configureWebview(document: SprottyDocument, webviewPanel: vscode.WebviewPanel, cancelToken: vscode.CancellationToken): Promise<void> | void {
         const extensionPath = this.options.extensionUri.fsPath;
         webviewPanel.webview.options = {
-            localResourceRoots: [ createFileUri(extensionPath, 'pack') ],
+            localResourceRoots: this.options.localResourceRoots ?? [ createFileUri(extensionPath, 'pack') ],
             enableScripts: true
         };
         const identifier = document.endpoint?.diagramIdentifier;
         if (identifier) {
-            const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
             if (this.options.createWebviewHtml) {
-                this.options.createWebviewHtml(identifier, webviewPanel, { scriptUri });
+                this.options.createWebviewHtml(identifier, webviewPanel);
             } else {
+                const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
                 webviewPanel.webview.html = createWebviewHtml(identifier, webviewPanel, { scriptUri });
             }
         }

--- a/packages/sprotty-vscode/src/sprotty-view-provider.ts
+++ b/packages/sprotty-vscode/src/sprotty-view-provider.ts
@@ -17,7 +17,7 @@
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import * as vscode from 'vscode';
 import { Messenger } from 'vscode-messenger';
-import { isWebviewView, IWebviewEndpointManager, OpenDiagramOptions, WebviewEndpoint } from './webview-endpoint';
+import { isWebviewView, IWebviewEndpointManager, OpenDiagramOptions, WebviewContainer, WebviewEndpoint } from './webview-endpoint';
 import { createFileUri, createWebviewHtml, getExtname, serializeUri } from './webview-utils';
 
 export interface SprottyViewProviderOptions {
@@ -26,6 +26,8 @@ export interface SprottyViewProviderOptions {
     messenger?: Messenger
     supportedFileExtensions?: string[];
     openActiveEditor?: boolean
+    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer,
+        options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }) => string
 }
 
 export interface OpenViewOptions extends OpenDiagramOptions {
@@ -122,7 +124,11 @@ export class SprottyViewProvider implements vscode.WebviewViewProvider, IWebview
             identifier = { clientId: this.clientId, diagramType: this.options.viewType, uri: '' };
         }
         const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
-        webviewView.webview.html = createWebviewHtml(identifier, webviewView, { scriptUri });
+        if (this.options.createWebviewHtml) {
+            webviewView.webview.html = this.options.createWebviewHtml(identifier, webviewView, { scriptUri });
+        } else {
+            webviewView.webview.html = createWebviewHtml(identifier, webviewView, { scriptUri });
+        }
     }
 
     protected async createDiagramIdentifier(uri: vscode.Uri, diagramType?: string): Promise<SprottyDiagramIdentifier | undefined> {

--- a/packages/sprotty-vscode/src/sprotty-view-provider.ts
+++ b/packages/sprotty-vscode/src/sprotty-view-provider.ts
@@ -24,10 +24,10 @@ export interface SprottyViewProviderOptions {
     extensionUri: vscode.Uri
     viewType: string
     messenger?: Messenger
-    supportedFileExtensions?: string[];
+    supportedFileExtensions?: string[]
     openActiveEditor?: boolean
-    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer,
-        options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }) => string
+    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer) => string
+    localResourceRoots?: vscode.Uri[]
 }
 
 export interface OpenViewOptions extends OpenDiagramOptions {
@@ -115,7 +115,7 @@ export class SprottyViewProvider implements vscode.WebviewViewProvider, IWebview
     protected configureWebview(webviewView: vscode.WebviewView, endpoint: WebviewEndpoint, cancelToken: vscode.CancellationToken): Promise<void> | void {
         const extensionPath = this.options.extensionUri.fsPath;
         webviewView.webview.options = {
-            localResourceRoots: [ createFileUri(extensionPath, 'pack') ],
+            localResourceRoots: this.options.localResourceRoots ?? [ createFileUri(extensionPath, 'pack') ],
             enableScripts: true
         };
         let identifier = endpoint.diagramIdentifier;
@@ -123,10 +123,10 @@ export class SprottyViewProvider implements vscode.WebviewViewProvider, IWebview
             // Create a preliminary diagram identifier to fill the webview's HTML content
             identifier = { clientId: this.clientId, diagramType: this.options.viewType, uri: '' };
         }
-        const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
         if (this.options.createWebviewHtml) {
-            webviewView.webview.html = this.options.createWebviewHtml(identifier, webviewView, { scriptUri });
+            webviewView.webview.html = this.options.createWebviewHtml(identifier, webviewView);
         } else {
+            const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
             webviewView.webview.html = createWebviewHtml(identifier, webviewView, { scriptUri });
         }
     }

--- a/packages/sprotty-vscode/src/webview-panel-manager.ts
+++ b/packages/sprotty-vscode/src/webview-panel-manager.ts
@@ -17,7 +17,7 @@
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import * as vscode from 'vscode';
 import { Messenger } from 'vscode-messenger';
-import { isWebviewPanel, IWebviewEndpointManager, OpenDiagramOptions, WebviewEndpoint } from './webview-endpoint';
+import { isWebviewPanel, IWebviewEndpointManager, OpenDiagramOptions, WebviewContainer, WebviewEndpoint } from './webview-endpoint';
 import { createFileUri, createWebviewPanel, createWebviewTitle, getExtname, serializeUri } from './webview-utils';
 
 export interface WebviewPanelManagerOptions {
@@ -26,6 +26,8 @@ export interface WebviewPanelManagerOptions {
     defaultDiagramType?: string
     supportedFileExtensions?: string[]
     singleton?: boolean
+    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer,
+        options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }) => string
 }
 
 export interface OpenPanelOptions extends OpenDiagramOptions {

--- a/packages/sprotty-vscode/src/webview-panel-manager.ts
+++ b/packages/sprotty-vscode/src/webview-panel-manager.ts
@@ -18,20 +18,20 @@ import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import * as vscode from 'vscode';
 import { Messenger } from 'vscode-messenger';
 import { isWebviewPanel, IWebviewEndpointManager, OpenDiagramOptions, WebviewContainer, WebviewEndpoint } from './webview-endpoint';
-import { createFileUri, createWebviewPanel, createWebviewTitle, getExtname, serializeUri } from './webview-utils';
+import { createFileUri, createWebviewHtml, createWebviewTitle, getExtname, serializeUri } from './webview-utils';
 
 export interface WebviewPanelManagerOptions {
-    extensionUri: vscode.Uri
-    messenger?: Messenger
-    defaultDiagramType?: string
-    supportedFileExtensions?: string[]
-    singleton?: boolean
-    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer,
-        options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }) => string
+    extensionUri: vscode.Uri;
+    messenger?: Messenger;
+    defaultDiagramType?: string;
+    supportedFileExtensions?: string[];
+    singleton?: boolean;
+    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer) => string;
+    localResourceRoots?: vscode.Uri[];
 }
 
 export interface OpenPanelOptions extends OpenDiagramOptions {
-    preserveFocus?: boolean
+    preserveFocus?: boolean;
 }
 
 /**
@@ -108,10 +108,27 @@ export class WebviewPanelManager implements IWebviewEndpointManager {
      */
     protected createWebview(identifier: SprottyDiagramIdentifier): vscode.WebviewPanel {
         const extensionPath = this.options.extensionUri.fsPath;
-        return createWebviewPanel(identifier, {
-            localResourceRoots: [ createFileUri(extensionPath, 'pack') ],
-            scriptUri: createFileUri(extensionPath, 'pack', 'webview.js')
-        });
+
+        const title = createWebviewTitle(identifier);
+        const diagramPanel = vscode.window.createWebviewPanel(
+            identifier.diagramType || 'diagram',
+            title,
+            vscode.ViewColumn.Beside,
+            {
+                localResourceRoots: this.options.localResourceRoots ?? [createFileUri(extensionPath, 'pack')],
+                enableScripts: true,
+                retainContextWhenHidden: true
+            }
+        );
+
+        if (this.options.createWebviewHtml) {
+            diagramPanel.webview.html = this.options.createWebviewHtml(identifier, diagramPanel);
+        } else {
+            const scriptUri = createFileUri(extensionPath, 'pack', 'webview.js');
+            diagramPanel.webview.html = createWebviewHtml(identifier, diagramPanel, { scriptUri });
+        }
+
+        return diagramPanel;
     }
 
     protected async createDiagramIdentifier(uri: vscode.Uri, diagramType?: string): Promise<SprottyDiagramIdentifier | undefined> {

--- a/packages/sprotty-vscode/src/webview-utils.ts
+++ b/packages/sprotty-vscode/src/webview-utils.ts
@@ -36,6 +36,7 @@ export function serializeUri(uri: vscode.Uri): string {
     return uriString;
 }
 
+/** @deprecated */
 export function createWebviewPanel(identifier: SprottyDiagramIdentifier,
     options: WebviewPanelOptions): vscode.WebviewPanel {
     const title = createWebviewTitle(identifier);

--- a/packages/sprotty-vscode/src/webview-utils.ts
+++ b/packages/sprotty-vscode/src/webview-utils.ts
@@ -19,14 +19,6 @@ import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import * as vscode from 'vscode';
 import type { WebviewContainer } from './webview-endpoint';
 
-interface WebviewPanelOptions {
-    localResourceRoots: vscode.Uri[]
-    scriptUri: vscode.Uri
-    cssUri?: vscode.Uri
-    createWebviewHtml?: (identifier: SprottyDiagramIdentifier, container: WebviewContainer,
-        options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }) => string
-}
-
 export function serializeUri(uri: vscode.Uri): string {
     let uriString = uri.toString();
     const matchDrive = uriString.match(/^file:\/\/\/([a-z])%3A/i);
@@ -38,7 +30,7 @@ export function serializeUri(uri: vscode.Uri): string {
 
 /** @deprecated */
 export function createWebviewPanel(identifier: SprottyDiagramIdentifier,
-    options: WebviewPanelOptions): vscode.WebviewPanel {
+    options: { localResourceRoots: vscode.Uri[], scriptUri: vscode.Uri, cssUri?: vscode.Uri; }): vscode.WebviewPanel {
     const title = createWebviewTitle(identifier);
     const diagramPanel = vscode.window.createWebviewPanel(
         identifier.diagramType || 'diagram',
@@ -49,20 +41,11 @@ export function createWebviewPanel(identifier: SprottyDiagramIdentifier,
             enableScripts: true,
             retainContextWhenHidden: true
         });
-
-    if (options.createWebviewHtml) {
-        diagramPanel.webview.html = options.createWebviewHtml(identifier, diagramPanel, {
-            scriptUri: options.scriptUri,
-            cssUri: options.cssUri,
-            title
-            });
-    } else {
-        diagramPanel.webview.html = createWebviewHtml(identifier, diagramPanel, {
-            scriptUri: options.scriptUri,
-            cssUri: options.cssUri,
-            title,
-        });
-    }
+    diagramPanel.webview.html = createWebviewHtml(identifier, diagramPanel, {
+        scriptUri: options.scriptUri,
+        cssUri: options.cssUri,
+        title,
+    });
     return diagramPanel;
 }
 
@@ -78,7 +61,7 @@ export function createWebviewTitle(identifier: SprottyDiagramIdentifier): string
 }
 
 export function createWebviewHtml(identifier: SprottyDiagramIdentifier, container: WebviewContainer,
-    options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string }): string {
+    options: { scriptUri: vscode.Uri, cssUri?: vscode.Uri, title?: string; }): string {
     const transformUri = (uri: vscode.Uri) => container.webview.asWebviewUri(uri).toString();
     return `<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Closes #20  

Adds meta Content-Security-Policy to the default webview html

The CSP allows local scripts and CSS, as well as inline-css

The default implementation can be customized by overriding the `createWebviewHtml` function or passing a new function as an option in the `WebviewPanelManager`, `SprottyEditorProvider`, or `SprottyViewProvider`